### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,5 @@ A web app that simulates a conveyor belt that sends speed data to IBM Watson IoT
 
 ### Deploy through Bluemix devOps
 
-[![Deploy to Bluemix](https://bluemix.net/deploy/button_x2.png)](https://bluemix.net/deploy?repository=) (via JazzHub)
-
 [![Create toolchain](https://bluemix.net/devops/graphics/create_toolchain_button.png)](https://bluemix.net/devops/setup/deploy?repository=) (via Continuous Delivery)
 


### PR DESCRIPTION
Remove "Deploy to Bluemix" button since that is deprecated and will stop on May 25: https://www.ibm.com/blogs/bluemix/2017/04/delivery-pipeline-retirement/